### PR TITLE
Clean-Up

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,14 @@
 GoFetch is a command line tool written in golang, the purpose of this program is to display information about your operating system, hardware and software. this project is inspired by neofetch!
 
 ## Requirement
+
 1. linux with systemd
 2. chafa
 
 ## Getting Started
+
 after executing program for the first time, you can change the image by modify file in `$HOME/.config/gofetch/config.json`
 
 ## Screen Shot
-![](Sample_Image/Pasted%20image%2020220529221507.png)
+
+![Sample Image](Sample_Image/Pasted%20image%2020220529221507.png)

--- a/config_parser.go
+++ b/config_parser.go
@@ -8,28 +8,27 @@ import (
 )
 
 var (
-	home_env = os.Getenv("HOME")
-	local_image = pwd()+"/sample.jpg"
-	remote_image = home_env+"/.config/gofetch/sample.jpg"
-
+	home_env     = os.Getenv("HOME")
+	local_image  = pwd() + "/sample.jpg"
+	remote_image = home_env + "/.config/gofetch/sample.jpg"
 )
 
 func deploy_sample_image() {
 	copy_file(local_image, remote_image)
 }
-func check_config_file() string{
-	file, err := os.Open(home_env+"/.config/gofetch/config.json")
-	pre_config := "# config file for gofetch\n"+
-	"image_location: "+home_env+"/.config/gofetch/sample.jpg"
+func check_config_file() string {
+	file, err := os.Open(home_env + "/.config/gofetch/config.json")
+	pre_config := "# config file for gofetch\n" +
+		"image_location: " + home_env + "/.config/gofetch/sample.jpg"
 	if err != nil {
 		// create config file
-		file, err := os.Create(home_env+"/.config/gofetch/config.json")
+		file, err := os.Create(home_env + "/.config/gofetch/config.json")
 		// init config file
 		if err != nil {
 			// create folder
 			os.Mkdir(home_env+"/.config/gofetch", 0755)
 			// create config file
-			file, err := os.Create(home_env+"/.config/gofetch/config.json")
+			file, err := os.Create(home_env + "/.config/gofetch/config.json")
 			if err != nil {
 				fmt.Println("Error:", err)
 				os.Exit(0)
@@ -50,7 +49,8 @@ func check_config_file() string{
 func get_image_location() string {
 	config_file := check_config_file()
 	re := regexp.MustCompile(`image_location: (.*)`)
-	image_location := strings.Replace(re.FindString(config_file), "image_location: ", "", -1)
+	image_location := strings.Replace(
+		re.FindString(config_file), "image_location: ", "", -1)
 	image_location = strings.Replace(image_location, "\n", "", -1)
 	image_location = strings.TrimSpace(image_location)
 	return image_location

--- a/get_info.go
+++ b/get_info.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 )
 
-
 func get_host_name() string { // get host name from /etc/hostname
 	host_file, err := os.Open("/etc/hostname")
 	if err != nil {
@@ -22,6 +21,7 @@ func get_host_name() string { // get host name from /etc/hostname
 	host_file_str = strings.Replace(host_file_str, "\n", "", -1)
 	return strings.TrimSpace(string(host_file_str))
 }
+
 func get_cpu_info(value string) string { // get cpu info from /proc/cpuinfo
 	// get cpu_info
 	cpu_file, err := os.Open("/proc/cpuinfo")
@@ -48,7 +48,9 @@ func get_cpu_info(value string) string { // get cpu info from /proc/cpuinfo
 	}
 	return cpu_tuples[value]
 }
-func get_cpu_stat(value string, value2 int) string { // get cpu stat from /proc/stat
+
+func get_cpu_stat(
+	value string, value2 int) string { // get cpu stat from /proc/stat
 	// get cpu_stat
 	stat_file, err := os.Open("/proc/stat")
 	if err != nil {
@@ -72,6 +74,7 @@ func get_cpu_stat(value string, value2 int) string { // get cpu stat from /proc/
 	}
 	return stat_tuples[value]
 }
+
 func get_mem_info(value string) string { //get memory info from /proc/meminfo
 	// get mem_info
 	mem_file, err := os.Open("/proc/meminfo")
@@ -93,11 +96,13 @@ func get_mem_info(value string) string { //get memory info from /proc/meminfo
 			kv := strings.Split(v, ":")
 			kv[0] = strings.TrimSpace(kv[0])
 			kv[1] = strings.TrimSpace(kv[1])
-			mem_tuples[strings.Replace(kv[0], " ", "", -1)] = strings.Replace(kv[1], " ", "", -1)
+			mem_tuples[strings.Replace(kv[0], " ", "", -1)] = strings.Replace(
+				kv[1], " ", "", -1)
 		}
 	}
 	return strings.TrimSpace(strings.Replace(mem_tuples[value], "kB", "", -1))
 }
+
 func get_vga_series() string { // get vga series from lspci
 	cmd := exec.Command("lspci")
 	// pipe the output of lspci to a variable
@@ -113,6 +118,7 @@ func get_vga_series() string { // get vga series from lspci
 	t2 := strings.TrimSpace(strings.Trim(string(strings.Trim(string(vga_info[1]), "[")), "/"))
 	return t1 + " " + t2
 }
+
 func get_monitor_size() string { // get monitor size
 	cmd := exec.Command("xdpyinfo")
 	// pipe the output of xdpyinfo to a variable
@@ -123,10 +129,13 @@ func get_monitor_size() string { // get monitor size
 	}
 	// find line that contains "dimensions:"
 	monitor_info := regexp.MustCompile(`dimensions:.*?x.*? `).FindAll(out, -1)
-	monitor_info_trim := strings.Trim(string(monitor_info[0]), "dimensions: ")
+	monitor_info_trim := strings.TrimPrefix(
+		string(monitor_info[0]),
+		"dimensions: ")
 	// return strings after ":" and before "x"
 	return strings.TrimSpace(monitor_info_trim)
 }
+
 func get_distro() string { // get distro from /etc/os-release
 	distro, err := os.Open("/etc/os-release")
 	if err != nil {
@@ -146,9 +155,11 @@ func get_distro() string { // get distro from /etc/os-release
 			distro_tuples[kv[0]] = kv[1]
 		}
 	}
-	return strings.Trim(distro_tuples["PRETTY_NAME"], "\"") 
+	return strings.Trim(distro_tuples["PRETTY_NAME"], "\"")
 }
-func get_computer_brand() string { // get computer brand from /sys/devices/virtual/dmi/id/
+
+func get_computer_brand() string {
+	// get computer brand from /sys/devices/virtual/dmi/id/
 	vendor, err1 := os.Open("/sys/devices/virtual/dmi/id/sys_vendor")
 	name, err2 := os.Open("/sys/devices/virtual/dmi/id/product_name")
 	if err1 != nil || err2 != nil {
@@ -161,15 +172,20 @@ func get_computer_brand() string { // get computer brand from /sys/devices/virtu
 	name.Read(name_info)
 	vendor.Close()
 	name.Close()
-	return strings.Replace(string(vendor_info),"\n", "", -1) + " " + strings.Replace(string(name_info),"\n", "", -1)
+
+	return strings.Replace(
+		string(vendor_info), "\n", "", -1) + " " + strings.Replace(string(name_info), "\n", "", -1)
 }
+
 func get_env(env string) string {
 	// get os enviroment
 	out := os.Getenv(env)
 	// get shell name
 	_out := strings.Split(out, "/")
+
 	return _out[len(_out)-1]
 }
+
 func get_kernel() string { // get kernel version from /proc/version
 	kernel_file, err := os.Open("/proc/version")
 	if err != nil {
@@ -182,6 +198,7 @@ func get_kernel() string { // get kernel version from /proc/version
 	kernel_list := strings.Split(string(kernel_info), " ")
 	return strings.TrimSpace(kernel_list[2])
 }
+
 func get_teminal_color_palette() string {
 	color1 := "\x1b[0;29m  \x1b[0m"
 	color2 := "\x1b[0;31m  \x1b[0m"

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/GoFetch
+module github.com/dimasma0305/GoFetch
 
 go 1.18

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module gofetch
+module github.com/GoFetch
 
 go 1.18

--- a/main.go
+++ b/main.go
@@ -5,9 +5,9 @@ import (
 )
 
 func main() {
-	//################################################################################
-	//#                                 preparation                                  #            
-	//################################################################################
+	//##########################################################################
+	//#                              preparation                               #
+	//##########################################################################
 
 	// checking
 	check_os()
@@ -27,27 +27,27 @@ func main() {
 		14,
 	))
 	clear_screen()
-	
-	//################################################################################
-	//#                              prepare variables                               #                  
-	//################################################################################
-	
+
+	//##########################################################################
+	//#                           prepare variables                            #
+	//##########################################################################
+
 	// Hardware Information
-	computer_brand 	:= get_computer_brand()
-	cpu_info 		:= get_cpu_info("model name")
-	memory_total 	:= kb_to_gb(get_mem_info("MemTotal"))
-	memory_used 	:= kb_to_gb(
+	computer_brand := get_computer_brand()
+	cpu_info := get_cpu_info("model name")
+	memory_total := kb_to_gb(get_mem_info("MemTotal"))
+	memory_used := kb_to_gb(
 		int2str(
-			str2int(get_mem_info("MemTotal")) - 
-			str2int(get_mem_info("MemFree")) - 
-			str2int(get_mem_info("Buffers")) -
-			str2int(get_mem_info("Cached")),
+			str2int(get_mem_info("MemTotal")) -
+				str2int(get_mem_info("MemFree")) -
+				str2int(get_mem_info("Buffers")) -
+				str2int(get_mem_info("Cached")),
 		),
 	)
 	memory_percent := percent(memory_used, memory_total)
 	vga_series := get_vga_series()
 	monitor_size := get_monitor_size()
-	
+
 	// Software Information
 	host_name := get_host_name()
 	distro := get_distro()
@@ -70,22 +70,47 @@ func main() {
 	icon_shell_name := color_templete("", 7)
 	icon_session := color_templete("", 7)
 
-	//################################################################################
-	//#                              print to terminal                               #                  
-	//################################################################################
-	
-	fmt.Print(template);fmt.Println(bold(coloring(" "+header+" ", "#c3c7d1")))
-	fmt.Print(template);fmt.Println(coloring(bold("┌───────── Hardware Information ─────────┐"), "828997"))
-	fmt.Print(template);fmt.Printf(	" %s  %s\n", icon_computer_brand, computer_brand)
-	fmt.Print(template);fmt.Printf(	" %s  %s\n", icon_cpu_info, cpu_info)
-	fmt.Print(template);fmt.Printf(	" %s %s / %s (%s)\n", 	icon_memory_total, memory_used, memory_total, memory_percent)
-	fmt.Print(template);fmt.Printf(	" %s  %s\n", icon_vga_series, vga_series)
-	fmt.Print(template);fmt.Printf(	" %s  %s\n", icon_monitor_size, monitor_size)
-	fmt.Print(template);fmt.Println(coloring(bold("├──────── Software Information ──────────┤"), "828997"))
-	fmt.Print(template);fmt.Printf( " %s  %s\n", icon_distro, distro)
-	fmt.Print(template);fmt.Printf( " %s  %s\n", icon_kernel_version, kernel_version)
-	fmt.Print(template);fmt.Printf( " %s  %s\n", icon_shell_name, shell_name)
-	fmt.Print(template);fmt.Printf( " %s  %s\n", icon_session, session)
-	fmt.Print(template);fmt.Println(coloring(bold("└────────────────────────────────────────┘"), "828997"))
-	fmt.Print(template);fmt.Println("      "+get_teminal_color_palette())
+	//##########################################################################
+	//#                           print to terminal                            #
+	//##########################################################################
+
+	fmt.Print(template)
+	fmt.Println(bold(coloring(" "+header+" ", "#c3c7d1")))
+	fmt.Print(template)
+
+	fmt.Println(
+		coloring(bold("┌───────── Hardware Information ─────────┐"), "828997"))
+	fmt.Print(template)
+	fmt.Printf(" %s  %s\n", icon_computer_brand, computer_brand)
+	fmt.Print(template)
+	fmt.Printf(" %s  %s\n", icon_cpu_info, cpu_info)
+	fmt.Print(template)
+	fmt.Printf(
+		" %s %s / %s (%s)\n",
+		icon_memory_total,
+		memory_used,
+		memory_total,
+		memory_percent)
+	fmt.Print(template)
+	fmt.Printf(" %s  %s\n", icon_vga_series, vga_series)
+	fmt.Print(template)
+	fmt.Printf(" %s  %s\n", icon_monitor_size, monitor_size)
+	fmt.Print(template)
+
+	fmt.Println(
+		coloring(bold("├──────── Software Information ──────────┤"), "828997"))
+	fmt.Print(template)
+	fmt.Printf(" %s  %s\n", icon_distro, distro)
+	fmt.Print(template)
+	fmt.Printf(" %s  %s\n", icon_kernel_version, kernel_version)
+	fmt.Print(template)
+	fmt.Printf(" %s  %s\n", icon_shell_name, shell_name)
+	fmt.Print(template)
+	fmt.Printf(" %s  %s\n", icon_session, session)
+	fmt.Print(template)
+
+	fmt.Println(
+		coloring(bold("└────────────────────────────────────────┘"), "828997"))
+	fmt.Print(template)
+	fmt.Println("      " + get_teminal_color_palette())
 }

--- a/tools.go
+++ b/tools.go
@@ -11,9 +11,9 @@ import (
 	"strings"
 )
 
-//################################################################################
-//#                                check related                                 #
-//################################################################################
+//##############################################################################
+//#                               check related                                #
+//##############################################################################
 
 func check_requirement() { //check if the requirement is met
 	// check chafa
@@ -23,6 +23,7 @@ func check_requirement() { //check if the requirement is met
 		os.Exit(0)
 	}
 }
+
 func check_os() { // check if the os is linux
 	if runtime.GOOS != "linux" {
 		fmt.Println("This is not a Linux system")
@@ -30,22 +31,28 @@ func check_os() { // check if the os is linux
 	}
 }
 
-//################################################################################
-//#                               display related                                #
-//################################################################################
+//##############################################################################
+//#                              display related                               #
+//##############################################################################
 
 func clear_screen() { // clear the screen but only the last output
 	os.Stdout.Write([]byte("\033[0;0H"))
 }
+
 func clear_screen_full() { // clear the screen
 	os.Stdout.Write([]byte("\033[H\033[2J"))
 }
-func display_image(location string, width int, height int) []byte { // display image using chafa
+
+func display_image(
+	location string,
+	width int,
+	height int) []byte { // display image using chafa
 	// convert width and height to string
 	width_str := strconv.Itoa(width)
 	height_str := strconv.Itoa(height)
 	// display an image using chafa
-	cmd := exec.Command("chafa", location, fmt.Sprintf("--size=%sx%s", width_str, height_str))
+	cmd := exec.Command(
+		"chafa", location, fmt.Sprintf("--size=%sx%s", width_str, height_str))
 	out, err := cmd.Output()
 	if err != nil {
 		fmt.Println("Error:", err)
@@ -53,9 +60,11 @@ func display_image(location string, width int, height int) []byte { // display i
 	}
 	return out
 }
+
 func bold(value string) string { // bold text
 	return fmt.Sprintf("\033[1m%s\033[0m", value)
 }
+
 func templete(_len int) string { // template for print
 	var _templete string
 	for i := 0; i < _len; i++ {
@@ -63,25 +72,26 @@ func templete(_len int) string { // template for print
 	}
 	return _templete
 }
-func coloring(text string,_hex string) string {
+func coloring(text string, _hex string) string {
 	_hex = strings.Trim(_hex, "#")
 	var (
-			r string
-			g string
-			b string
+		r string
+		g string
+		b string
 	)
 	if len(_hex) == 6 {
-			r = _hex[0:2]
-			g = _hex[2:4]
-			b = _hex[4:6]
+		r = _hex[0:2]
+		g = _hex[2:4]
+		b = _hex[4:6]
 	} else {
-			return text
+		return text
 	}
 	rgb, err := hex.DecodeString(r + g + b)
 	if err != nil {
-			return text
+		return text
 	}
-	return fmt.Sprintf("\x1b[38;2;%d;%d;%dm%s\x1b[0m", rgb[0], rgb[1], rgb[2], text)
+	return fmt.Sprintf(
+		"\x1b[38;2;%d;%d;%dm%s\x1b[0m", rgb[0], rgb[1], rgb[2], text)
 }
 func make_header(text string, _len int) string {
 	var foo string
@@ -90,7 +100,7 @@ func make_header(text string, _len int) string {
 			foo += text
 		}
 		foo += "─"
-		if i == _len - len(text) {
+		if i == _len-len(text) {
 			break
 		}
 	}
@@ -118,9 +128,9 @@ func color_templete(txt string, value int) string { // color templete
 	return txt
 }
 
-//################################################################################
-//#                              convertion related                              #                   
-//################################################################################
+//##############################################################################
+//#                             convertion related                             #
+//##############################################################################
 
 func kb_to_gb(kb_str string) string { // convert kb to gb
 	kb_str = strings.Replace(kb_str, "kB", "", -1)
@@ -132,6 +142,7 @@ func kb_to_gb(kb_str string) string { // convert kb to gb
 	gb := float64(kb) / 1024 / 1024
 	return fmt.Sprintf("%.2f", gb)
 }
+
 func percent(value string, value2 string) string { // calculate percent
 	// convert value and value2 to float64
 	value_float, err := strconv.ParseFloat(value, 64)
@@ -148,6 +159,7 @@ func percent(value string, value2 string) string { // calculate percent
 	percent := value_float / value2_float * 100
 	return fmt.Sprintf("%.2f%%", percent)
 }
+
 func str2int(str string) int { // convert string to int
 	i, err := strconv.Atoi(str)
 	if err != nil {
@@ -156,13 +168,14 @@ func str2int(str string) int { // convert string to int
 	}
 	return i
 }
+
 func int2str(value int) string { // convert int to string
 	return strconv.Itoa(value)
 }
 
-//################################################################################
-//#                                 open related                                 #             
-//################################################################################
+//##############################################################################
+//#                                open related                                #
+//##############################################################################
 
 func pwd() string { // open file and read
 	get_pwd, err := os.Getwd()
@@ -172,6 +185,7 @@ func pwd() string { // open file and read
 	}
 	return get_pwd
 }
+
 func copy_file(src string, dst string) error { // copy file
 	// open file
 	src_file, err := os.Open(src)


### PR DESCRIPTION
- Updated `go.mod` to enable installation through `go install`
- Removed _long lines_ (exceeding 80 characters) and added spacing between functions
- Fixed static-check warning concerning the usage of the `Trim` function using `TrimPrefix`